### PR TITLE
Fix display of empty profiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ resumeObject.basics.capitalLabel = (resumeObject.basics.label).toUpperCase();
 	if (resumeObject.basics.profiles) {
 		if (resumeObject.basics.profiles[0].network) {
 			_.each(resumeObject.basics.profiles, function(w){
+			  resumeObject.profilesBool = true;
 				if ((w.network == 'Twitter' || w.network == 'twitter') && w.url == '' && w.username != '') {
 					w.url = "https://twitter.com/" + w.username;
 				}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-classy",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "An uber-classy JSONResume theme.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-classy",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "An uber-classy JSONResume theme.",
   "main": "index.js",
   "scripts": {

--- a/resume.template
+++ b/resume.template
@@ -172,6 +172,7 @@
 			</div>
 			{{/websiteBool}}
 		</div>
+		{{#profilesBool}}
 		<br>
 		<div id= "profiles">
 			<div class= "contact-header">PROFILES</div><br>
@@ -179,6 +180,7 @@
 			<p class= "profile"><a href= "{{url}}" target= "_blank" class= "profile">{{network}}</a></p>
 			{{/basics.profiles}}
 		</div>		
+		{{/profilesBool}}
 	</div>
 	<div class= "main">
 		{{#aboutBool}}

--- a/resume.template
+++ b/resume.template
@@ -151,7 +151,7 @@
 		<h1>{{basics.capitalName}}</h1>
 		<h3 class= "label">{{basics.capitalLabel}}</h3>
 		<div class= "contact-header">
-				{{basics.location.city}}, {{basics.location.region}}, {{basics.location.countryCode}}<br>
+				{{basics.location.city}}, {{basics.location.countryCode}}<br>
 				{{basics.location.address}}
 			</div>
 		<div id= "contact">

--- a/resume.template
+++ b/resume.template
@@ -196,8 +196,8 @@
 			<h2><i class= "fa fa-suitcase left"></i> WORK EXPERIENCE</h2>
 			{{#work}}
 				<div class= "job">
-					<h3>{{position}}, {{company}}</h3>
-					<h4>{{startDateMonth}}{{startDateYear}} - {{endDateMonth}}{{endDateYear}}</h4>
+          <h3>{{position}}<br /><small>{{company}}</small></h3>
+					<h4>{{startDateMonth}}{{startDateYear}} – {{endDateMonth}}{{endDateYear}}</h4>
 					<p>{{summary}}</p>
 					{{#workHighlights}}
 					<h4>HIGHLIGHTS</h4>
@@ -215,8 +215,8 @@
 		<div id= "volunteer">
 			<h2><i class= "fa fa-child left"></i> VOLUNTEER WORK</h2>
 			{{#volunteer}}
-			<h3>{{position}}, {{organization}}</h3>
-			<h4>{{startDateMonth}}{{startDateYear}} - {{endDateMonth}}{{endDateYear}}</h4>
+      <h3>{{position}}<br><small>{{organization}}</small></h3>
+			<h4>{{startDateMonth}}{{startDateYear}} – {{endDateMonth}}{{endDateYear}}</h4>
 			<p>{{summary}}<br><a href= "{{website}}" target= "_blank">{{website}}</a></p>
 			{{#volunterHighlights}}
 			<h4>HIGHLIGHTS</h4>
@@ -244,11 +244,10 @@
 		<div id= "education">
 			<h2><i class= "fa fa-graduation-cap left"></i> EDUCATION</h2>
 			{{#education}}
-				<h3>{{studyType}}, {{area}} - {{institution}}</h3>
-				<h4>{{startDateMonth}}{{startDateYear}} - {{endDateMonth}}{{endDateYear}}{{#gpaBool}}<br>
-				GPA: {{gpa}}{{/gpaBool}}</h4>
+      <h3>{{studyType}}, {{area}}<br><small>{{institution}}</small></h3>
+				<h4>{{startDateMonth}}{{startDateYear}} – {{endDateMonth}}{{endDateYear}}{{#gpaBool}}<br>
+				Award: {{gpa}}{{/gpaBool}}</h4>
 				{{#educationCourses}}
-				<h4>COURSES</h4>
 				<ul>
 					{{#courses}}
 					<li>{{.}}</li>


### PR DESCRIPTION
When a resume does not include any profiles, the output still included the profiles header.

This pull request brings the profiles behaviour into line with the rest of the sections which hide when they are empty.